### PR TITLE
Fix dependencies to work with latest grpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ have extended and released under the same [`LICENSE`](./LICENSE)
 Installation
 ------------
 
-**The current version of this library requires gRPC version 1.2.0. Newer versions may work but have not been tested.**
+**The current version of this library requires gRPC version 1.14.0. Newer versions may work but have not been tested.**
 
 Usage
 -----

--- a/core/cbits/grpc_haskell.c
+++ b/core/cbits/grpc_haskell.c
@@ -535,12 +535,13 @@ grpc_call_credentials* grpc_metadata_credentials_create_from_plugin_(
 //This callback is registered as the get_metadata callback for the call, and its
 //only job is to cast the void* state pointer to the correct function pointer
 //type and call the Haskell function with it.
-void metadata_dispatcher(void *state, grpc_auth_metadata_context context,
-                         grpc_credentials_plugin_metadata_cb cb, void *user_data, grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
-                         size_t* num_creds_md, grpc_status_code* status,
-                         const char** error_details){
+int metadata_dispatcher(void *state, grpc_auth_metadata_context context,
+                        grpc_credentials_plugin_metadata_cb cb, void *user_data, grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
+                        size_t* num_creds_md, grpc_status_code* status,
+                        const char** error_details){
 
   ((haskell_get_metadata*)state)(&context, cb, user_data);
+  return 0;
 }
 
 grpc_metadata_credentials_plugin* mk_metadata_client_plugin(

--- a/core/cbits/grpc_haskell.c
+++ b/core/cbits/grpc_haskell.c
@@ -498,10 +498,10 @@ grpc_channel_credentials* grpc_ssl_credentials_create_internal(
   grpc_channel_credentials* creds;
   if(pem_key && pem_cert){
     grpc_ssl_pem_key_cert_pair pair = {pem_key, pem_cert};
-    creds = grpc_ssl_credentials_create(pem_root_certs, &pair, NULL);
+    creds = grpc_ssl_credentials_create(pem_root_certs, &pair, NULL, NULL);
   }
   else{
-    creds = grpc_ssl_credentials_create(pem_root_certs, NULL, NULL);
+    creds = grpc_ssl_credentials_create(pem_root_certs, NULL, NULL, NULL);
   }
   return creds;
 }

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -206,9 +206,9 @@ test-suite tests
     , unix
     , time
     , async
-    , tasty >= 1.0 && <1.1
+    , tasty >= 1.0 && <1.2
     , tasty-hunit >= 0.10 && <0.11
-    , tasty-quickcheck >= 0.9.2 && < 0.10
+    , tasty-quickcheck >= 0.9.2 && < 0.11
     , containers ==0.5.*
     , managed >= 1.0.0 && < 1.1
     , pipes >=4.1 && <=4.4


### PR DESCRIPTION
The README calls for version 1.2.0, which is wildly out of date.  This is an attempt to see if get to the latest version without any major rewrites.  (Hopefully it's just minor changes to function signatures...🤞)